### PR TITLE
Fixed issue loading up the Warp room Zone 10_2Z.

### DIFF
--- a/CrashEdit/Controls/NewSceneryEntryViewer.cs
+++ b/CrashEdit/Controls/NewSceneryEntryViewer.cs
@@ -236,7 +236,8 @@ namespace CrashEdit
                                     {
                                         ++tex;
                                         anim = entry.AnimatedTextures[tex];
-                                        tex = anim.Offset - 1 + anim.LOD0;
+                                        // tex = anim.Offset - 1 + anim.LOD0;
+                                        tex = anim.Offset - 1 + (anim.Data >> 29 & 0x3);
                                     }
                                     if (entry.Textures[tex].BlendMode == 1)
                                         lastquads[e].Add(q);


### PR DESCRIPTION
The Zone would fail and break the Zone Viewer because the Scenery to it (2__2W) was broken due to this line. This from visual tests seems to work I think.

However why is the monitor on the top of the area not animated like it does in game? Maybe these are the animated textures that are failing.

Issue was with Crash Bandicoot 3 (SCUS 942.44).