### PR TITLE
Fixed bug in exporting Sceneries as OBJ.

### DIFF
--- a/Crash/Formats/Crash Formats/Scenery/NewSceneryEntry.cs
+++ b/Crash/Formats/Crash Formats/Scenery/NewSceneryEntry.cs
@@ -105,11 +105,11 @@ namespace Crash
                         if (vertex.Color < Colors.Count)
                         {
                             SceneryColor color = Colors[vertex.Color];
-                            obj.WriteLine("v {0} {1} {2} {3} {4} {5}", vertex.X + XOffset / 4, vertex.Y + YOffset / 4, vertex.Z + ZOffset / 4,color.Red / 255.0,color.Green / 255.0,color.Blue / 255.0);
+                            obj.WriteLine("v {0} {1} {2} {3} {4} {5}", vertex.X + XOffset / 16, vertex.Y + YOffset / 16, vertex.Z + ZOffset / 16,color.Red / 255.0,color.Green / 255.0,color.Blue / 255.0);
                         }
                         else
                         {
-                            obj.WriteLine("v {0} {1} {2}", vertex.X + XOffset / 4, vertex.Y + YOffset / 4, vertex.Z + ZOffset / 4);
+                            obj.WriteLine("v {0} {1} {2}", vertex.X + XOffset / 16, vertex.Y + YOffset / 16, vertex.Z + ZOffset / 16);
                         }
                     }
                     obj.WriteLine();


### PR DESCRIPTION
So on the obj exporter you guys divide by 4 instead of 16 but divide by 16 on the ply exporter.

Also it might look fine on 1 scenery, until you start to export all of them into a single obj file.

Without this change it will look like there is a gap, but instead the area is most likely too small or large to fit together.

![image](https://user-images.githubusercontent.com/15173749/71475060-93750780-27ac-11ea-9f73-e8c52be7d8ff.png)
This is what happens when I changed it to this on the Alpha version of the warp room.

And it should do the same for the final version of 3 as well unlike what was going on:

![image](https://user-images.githubusercontent.com/15173749/71475128-ed75cd00-27ac-11ea-80b2-75a3a90557c6.png)
