### PR TITLE
Refactor 3D viewer class structure

### DIFF
--- a/Crash/Formats/Crash Formats/Animation/Frame.cs
+++ b/Crash/Formats/Crash Formats/Animation/Frame.cs
@@ -116,7 +116,7 @@ namespace CrashEdit.Crash
 
         private List<FrameCollision> collision;
         private List<FrameVertex> vertices;
-        public IList<Position> MakeVertices(ModelEntry model)
+        public IList<Position> MakeVertices(ModelEntry? model)
         {
             IList<Position> verts = new Position[Vertices.Count];
             if (model != null && model.Positions != null)

--- a/Crash/Formats/Crash Formats/NSF.cs
+++ b/Crash/Formats/Crash Formats/NSF.cs
@@ -248,12 +248,12 @@ namespace CrashEdit.Crash
             }
         }
 
-        public T GetEntry<T>(string ename) where T : class, IEntry
+        public T? GetEntry<T>(string ename) where T : class, IEntry
         {
             return GetEntry<T>(Entry.ENameToEID(ename));
         }
 
-        public T GetEntry<T>(int eid) where T : class, IEntry
+        public T? GetEntry<T>(int eid) where T : class, IEntry
         {
             if (eid == Entry.NullEID || !Entry.ValidEID(eid))
                 return null;

--- a/Crash/Formats/Crash Formats/Scenery/SceneryVertex.cs
+++ b/Crash/Formats/Crash Formats/Scenery/SceneryVertex.cs
@@ -1,6 +1,6 @@
 namespace CrashEdit.Crash
 {
-    public struct SceneryVertex
+    public readonly struct SceneryVertex
     {
         public static SceneryVertex Load(byte[] xydata, byte[] zdata, bool is_c3 = false)
         {

--- a/Crash/LevelWorkspace.cs
+++ b/Crash/LevelWorkspace.cs
@@ -10,6 +10,36 @@ namespace CrashEdit.Crash
         public NSF? NSF { get; set; }
 
         public Dictionary<int, IEntry> AllEntriesByEid { get; } = [];
+        
+        public T? GetEntry<T>(int eid) where T : class
+        {
+            if (AllEntriesByEid.TryGetValue(eid, out var entry))
+                return entry as T; // this will be null if it's not in the type we want
+            else
+                return null;
+        }
+
+        public IEnumerable<T> GetEntries<T>() where T : class
+        {
+            var list = new List<T>();
+            foreach (var entry in AllEntriesByEid.Values)
+            {
+                if (entry is T want)
+                    list.Add(want);
+            }
+            return list;
+        }
+
+        public IEnumerable<int> GetEntriesEID<T>() where T : class
+        {
+            var list = new List<int>();
+            foreach (var kvp in AllEntriesByEid)
+            {
+                if (kvp.Value is T)
+                    list.Add(kvp.Key);
+            }
+            return list;
+        }
 
         public override void Sync()
         {

--- a/CrashEdit/Controllers/Controller.cs
+++ b/CrashEdit/Controllers/Controller.cs
@@ -24,9 +24,9 @@ namespace CrashEdit.CE
             return (Modern.Root.Resource as LevelWorkspace)?.NSF;
         }
 
-        public T GetEntry<T>(int eid) where T : class, IEntry
+        public T? GetEntry<T>(int eid) where T : class, IEntry
         {
-            return (Modern.Root.Resource as LevelWorkspace)?.NSF?.GetEntry<T>(eid);
+            return (Modern.Root?.Resource as LevelWorkspace)?.NSF?.GetEntry<T>(eid);
         }
 
         public IEnumerable<T> GetEntries<T>() where T : class, IEntry

--- a/CrashEdit/Controllers/Zone/OldZoneEntryController.cs
+++ b/CrashEdit/Controllers/Zone/OldZoneEntryController.cs
@@ -31,23 +31,17 @@ namespace CrashEdit.CE
         void Menu_AddEntity()
         {
             short id = 6;
-            while (true)
+            var entities = new List<OldEntity>();
+
+            foreach (OldZoneEntry zone in GetEntries<OldZoneEntry>())
             {
-                foreach (OldZoneEntry zone in GetEntries<OldZoneEntry>())
-                {
-                    foreach (OldEntity otherentity in zone.Entities)
-                    {
-                        if (otherentity.ID == id)
-                        {
-                            goto FOUND_ID;
-                        }
-                    }
-                }
-                break;
-            FOUND_ID:
-                ++id;
-                continue;
+                entities.AddRange(zone.Entities);
             }
+            while (entities.Find(x => x.ID == id) != null)
+            {
+                ++id;
+            }
+
             OldEntity newentity = OldEntity.Load(new OldEntity(0x0018, 3, 0, id, 0, 0, 0, 0, 0, new List<EntityPosition>() { new EntityPosition(0, 0, 0) }, 0).Save());
             OldZoneEntry.Entities.Add(newentity);
         }

--- a/CrashEdit/Controls/3D/AnimationEntryViewer.cs
+++ b/CrashEdit/Controls/3D/AnimationEntryViewer.cs
@@ -1,63 +1,24 @@
-using CrashEdit.CE.Properties;
 using CrashEdit.Crash;
-using OpenTK.Graphics.OpenGL4;
 using OpenTK.Mathematics;
 
 namespace CrashEdit.CE
 {
-    public sealed class AnimationEntryViewer : GLViewer
+    public sealed class AnimationEntryViewer : BaseAnimationEntryViewer
     {
-        private readonly int eid_anim;
-        private readonly int frame_id;
-        private readonly int model_eid;
-        private int cur_frame = 0;
-        private bool enable_collision = Settings.Default.DisplayFrameCollision;
-        private bool enable_interp = true;
-        private int cull_mode = 1;
+        private bool _halfspeed = false;
 
-        private static VBO[] vboModel;
-        private VAO[] vaoModel = new VAO[2];
-        private BlendMode blend_mask;
-
-        private readonly Vector3[][] transUncompressedVerts = new Vector3[2][];
-
-        public AnimationEntryViewer(NSF nsf, int anim_eid, int frame = -1, int model_eid = Entry.NullEID) : base(nsf)
-        {
-            eid_anim = anim_eid;
-            frame_id = frame;
-            this.model_eid = model_eid;
-
-            for (int i = 0; i < 2; ++i)
-            {
-                transUncompressedVerts[i] = [];
-            }
-        }
-
-        private static void LoadGLStatic()
-        {
-            vboModel = [new(), new()];
-        }
-
-        protected override void LoadGL()
-        {
-            base.LoadGL();
-
-            for (int i = 0; i < 2; ++i)
-            {
-                vaoModel[i] = new(shaders.GetShader("crash1"), PrimitiveType.Triangles, vboModel[i]);
-            }
-        }
+        public AnimationEntryViewer(NSF nsf, int anim_eid, int frame = -1, int model_eid = Entry.NullEID) : base(nsf, anim_eid, frame, model_eid) { }
 
         protected override IEnumerable<IPosition> CorePositions
         {
             get
             {
-                IList<Frame> frames = nsf.GetEntry<AnimationEntry>(eid_anim)?.Frames;
+                var frames = nsf.GetEntry<AnimationEntry>(animId)?.Frames;
                 if (frames != null)
                 {
                     var usedframes = new List<Frame>();
-                    if (frame_id != -1)
-                        usedframes.Add(frames[frame_id]);
+                    if (animFrame != -1)
+                        usedframes.Add(frames[animFrame]);
                     else
                         usedframes.AddRange(frames);
 
@@ -73,10 +34,11 @@ namespace CrashEdit.CE
                             my = model.ScaleY / GameScales.ModelC1 / GameScales.AnimC1;
                             mz = model.ScaleZ / GameScales.ModelC1 / GameScales.AnimC1;
                         }
+                        var frame_offset = new Position(frame.XOffset / 4f, frame.YOffset / 4f, frame.ZOffset / 4f);
+                        var scale = new Position(mx, my, mz);
                         foreach (var vert in frame.MakeVertices(model))
                         {
-                            yield return (new Position(vert.X, vert.Z, vert.Y)
-                                        + new Position(frame.XOffset / 4f, frame.YOffset / 4f, frame.ZOffset / 4f)) * new Position(mx, my, mz);
+                            yield return (new Position(vert.X, vert.Z, vert.Y) + frame_offset) * scale;
                         }
                     }
                 }
@@ -85,63 +47,58 @@ namespace CrashEdit.CE
 
         private int GetModelEID(Frame frame)
         {
-            return model_eid != Entry.NullEID ? model_eid : frame.ModelEID;
+            return modelId != Entry.NullEID ? modelId : frame.ModelEID;
         }
 
         protected override void Render()
         {
             base.Render();
 
-            IList<Frame> frames = nsf.GetEntry<AnimationEntry>(eid_anim)?.Frames;
+            tpages.Clear();
+
+            var frames = nsf.GetEntry<AnimationEntry>(animId)?.Frames;
             if (frames != null)
             {
-                Frame frame2 = null;
+                Frame? frame2 = null;
                 float interp = 0;
                 if (frames.Count == 1)
-                {
-                    cur_frame = 0;
-                }
-                else if (frame_id != -1)
-                {
-                    cur_frame = frame_id;
-                }
+                    _curframe = 0;
+                else if (animFrame != -1)
+                    _curframe = animFrame;
                 else
                 {
                     double prog = render.FullCurrentFrame / 2;
-                    cur_frame = (int)Math.Floor(prog) % frames.Count;
-                    if (enable_interp)
+                    if (_halfspeed)
+                        prog /= 2;
+                    _curframe = (int)((long)Math.Floor(prog) % frames.Count);
+                    if (_interpolate)
                     {
                         frame2 = frames[(int)Math.Ceiling(prog) % frames.Count];
-                        interp = (float)(prog - Math.Floor(prog));
-                        // Console.WriteLine(string.Format("Render frame {1}+{2}/{0} (i {3})", anim.Frames.Count, cur_frame, (int)Math.Ceiling(prog) % anim.Frames.Count, interp));
+                        interp = (float)(prog - Math.Truncate(prog));
+                    }
+                    else if (_halfspeed)
+                    {
+                        if (((long)(prog * 2) & 0x1) != 0)
+                        {
+                            frame2 = frames[(_curframe + 1) % frames.Count];
+                            interp = 0.5f;
+                        }
                     }
                 }
-                Frame frame1 = frames[cur_frame];
-                if (frame2 != null && (GetModelEID(frame2) != GetModelEID(frame1) || frame1.Vertices.Count != frame2.Vertices.Count))
-                    frame2 = null;
-
-                var model = nsf.GetEntry<ModelEntry>(GetModelEID(frame1));
-                if (model == null) return;
+                Frame frame1 = frames[_curframe];
 
                 blend_mask = BlendMode.Solid;
 
-                // uniforms and static data
-                vaoModel[0].UserTrans = new Vector3(frame1.XOffset, frame1.YOffset, frame1.ZOffset) / 4;
-                vaoModel[0].UserScale = new Vector3(model.ScaleX, model.ScaleY, model.ScaleZ) / (GameScales.ModelC1 * GameScales.AnimC1);
-                vaoModel[0].UserCullMode = cull_mode;
-
                 RenderFrame(frame1, 0);
 
-                if (frame2 != null && frame2 != frame1)
+                if (frame2 != null && frame2 != frame1 && frame1.Vertices.Count == frame2.Vertices.Count)
                 {
-                    MathExt.Lerp(ref vaoModel[0].UserTrans, new Vector3(frame2.XOffset, frame2.YOffset, frame2.ZOffset) / 4, interp);
-
                     // lerp results
                     RenderFrame(frame2, 1);
 
                     for (int i = 0; i < frame1.SpecialVertexCount; ++i)
                     {
-                        MathExt.Lerp(ref transUncompressedVerts[0][i], transUncompressedVerts[1][i], interp);
+                        MathExt.Lerp(ref vertCache[0][i], vertCache[1][i], interp);
                     }
                     for (int i = 0; i < vaoModel[0].CurVert; ++i)
                     {
@@ -150,18 +107,24 @@ namespace CrashEdit.CE
                     }
                 }
 
+                UploadTPAGs();
+
                 for (int i = 0; i < frame1.SpecialVertexCount; ++i)
                 {
-                    AddSprite((transUncompressedVerts[0][i] + vaoModel[0].UserTrans) * vaoModel[0].UserScale, new Vector2(0.35f), (Rgba)Color4.Magenta, OldResources.PointTexture);
+                    AddSprite(vertCache[0][i], new Vector2(0.32f), (Rgba)Color4.Magenta, OldResources.PointTexture);
                 }
 
                 // note: only buffer 0 is rendered
+                vaoModel[0].UserCullMode = _cullmode;
                 RenderFramePass(BlendMode.Solid);
-                RenderFramePass(BlendMode.Trans);
-                RenderFramePass(BlendMode.Subtractive);
-                RenderFramePass(BlendMode.Additive);
+                if (render.EnableTexture)
+                {
+                    RenderFramePass(BlendMode.Trans);
+                    RenderFramePass(BlendMode.Subtractive);
+                    RenderFramePass(BlendMode.Additive);
+                }
 
-                if (enable_collision)
+                if (_collision)
                 {
                     foreach (var col in frame1.Collision)
                     {
@@ -174,68 +137,59 @@ namespace CrashEdit.CE
                         AddBox(pos, size, new Rgba(0, 255, 0, 255), true);
                     }
                 }
-
-                // restore things
-                vaoModel[0].UserTrans = new Vector3(0);
-                vaoModel[0].UserScale = new Vector3(1);
-                vaoModel[0].UserCullMode = 0;
             }
         }
 
         protected override void PrintHelp()
         {
             base.PrintHelp();
-            con_help += KeyboardControls.ToggleCollisionAnim.Print(OnOffName(enable_collision));
-            con_help += KeyboardControls.ToggleLerp.Print(OnOffName(enable_interp));
-            con_help += KeyboardControls.ChangeCullMode.Print(CullModeName(cull_mode));
+            con_help += KeyboardControls.ToggleSlowAnim.Print(OnOffName(_halfspeed));
         }
 
         protected override void RunLogic()
         {
             base.RunLogic();
-            if (KPress(KeyboardControls.ToggleCollisionAnim)) enable_collision = !enable_collision;
-            if (KPress(KeyboardControls.ToggleLerp)) enable_interp = !enable_interp;
-            if (KPress(KeyboardControls.ChangeCullMode)) cull_mode = ++cull_mode % 3;
+            if (KPress(KeyboardControls.ToggleSlowAnim)) _halfspeed = !_halfspeed;
         }
 
-        private Dictionary<int, short> CollectTPAGs(ModelEntry model)
+        private void AddTPAGs(ModelEntry model)
         {
             // collect tpag eids
-            Dictionary<int, short> tex_eids = new();
             for (int i = 0, m = model.TPAGCount; i < m; ++i)
             {
                 int tpag_eid = model.GetTPAG(i);
-                if (!tex_eids.ContainsKey(tpag_eid))
-                    tex_eids[tpag_eid] = (short)tex_eids.Count;
+                if (!tpages.ContainsKey(tpag_eid))
+                    tpages[tpag_eid] = (short)tpages.Count;
             }
-            return tex_eids;
         }
 
         private void RenderFrame(Frame frame, int buf)
         {
+            var vao = vaoModel[buf];
+            vao.DiscardVerts();
+
             var model = nsf.GetEntry<ModelEntry>(GetModelEID(frame));
             if (model != null)
             {
                 // setup textures
-                var tex_eids = CollectTPAGs(model);
-                SetupTPAGs(tex_eids);
+                AddTPAGs(model);
 
                 // alloc buffers
-                var vao = vaoModel[buf];
                 vao.TestRealloc(model.Triangles.Count * 3);
-                vao.DiscardVerts();
-                if (transUncompressedVerts[buf].Length < frame.SpecialVertexCount)
+                if (vertCache[buf].Length < frame.SpecialVertexCount)
                 {
-                    Array.Resize(ref transUncompressedVerts[buf], frame.SpecialVertexCount);
+                    Array.Resize(ref vertCache[buf], frame.SpecialVertexCount);
                 }
 
                 // decompress vertices, on the fly right now
                 var verts = frame.MakeVertices(model);
+                var trans = new Vector3(frame.XOffset, frame.YOffset, frame.ZOffset) / 4;
+                var scale = new Vector3(model.ScaleX, model.ScaleY, model.ScaleZ) / (GameScales.ModelC1 * GameScales.AnimC1);
 
                 // render stuff
                 for (int i = 0; i < frame.SpecialVertexCount; ++i)
                 {
-                    transUncompressedVerts[buf][i] = new Vector3(verts[i].X, verts[i].Z, verts[i].Y);
+                    vertCache[buf][i] = (new Vector3(verts[i].X, verts[i].Z, verts[i].Y) + trans) * scale;
                 }
                 foreach (var tri in model.Triangles)
                 {
@@ -247,7 +201,7 @@ namespace CrashEdit.CE
                     if (polygon_texture_info != null)
                     {
                         var info = polygon_texture_info;
-                        tex = new(tex_eids[model.GetTPAG(info.Page)], color: info.ColorMode, blend: info.BlendMode, clutx: info.ClutX, cluty: info.ClutY, face: nocull ? 1 : 0);
+                        tex = new(tpages[model.GetTPAG(info.Page)], color: info.ColorMode, blend: info.BlendMode, clutx: info.ClutX, cluty: info.ClutY, face: nocull ? 1 : 0);
                         vao.Verts[vao.CurVert + 1].st = new(info.X2, info.Y2);
                         if ((tri.Type != 2 && !flip) || (tri.Type == 2 && tri.Subtype == 1))
                         {
@@ -274,31 +228,11 @@ namespace CrashEdit.CE
                         var c = model.Colors[tri.Color[v_n]];
                         var v = verts[tri.Vertex[v_n] + frame.SpecialVertexCount];
                         vao.Verts[vao.CurVert].rgba = new(c.Red, c.Green, c.Blue, 255);
-                        vao.Verts[vao.CurVert].trans = new(v.X, v.Z, v.Y);
+                        vao.Verts[vao.CurVert].trans = (new Vector3(v.X, v.Z, v.Y) + trans) * scale;
                         vao.CurVert++;
                     }
                 }
             }
-        }
-
-        private void RenderFramePass(BlendMode pass)
-        {
-            if ((pass & blend_mask) != BlendMode.None)
-            {
-                SetBlendMode(pass);
-                vaoModel[0].BlendMask = BlendModeIndex(pass);
-                vaoModel[0].Render(render);
-            }
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            for (var i = 0; i < vaoModel.Length; ++i)
-            {
-                vaoModel[i]?.Dispose();
-            }
-
-            base.Dispose(disposing);
         }
     }
 }

--- a/CrashEdit/Controls/3D/AnimationEntryViewer.cs
+++ b/CrashEdit/Controls/3D/AnimationEntryViewer.cs
@@ -114,15 +114,7 @@ namespace CrashEdit.CE
                     AddSprite(vertCache[0][i], new Vector2(0.32f), (Rgba)Color4.Magenta, OldResources.PointTexture);
                 }
 
-                // note: only buffer 0 is rendered
-                vaoModel[0].UserCullMode = _cullmode;
-                RenderFramePass(BlendMode.Solid);
-                if (render.EnableTexture)
-                {
-                    RenderFramePass(BlendMode.Trans);
-                    RenderFramePass(BlendMode.Subtractive);
-                    RenderFramePass(BlendMode.Additive);
-                }
+                RenderPasses();
 
                 if (_collision)
                 {

--- a/CrashEdit/Controls/3D/BaseAnimationEntryViewer.cs
+++ b/CrashEdit/Controls/3D/BaseAnimationEntryViewer.cs
@@ -74,6 +74,19 @@ namespace CrashEdit.CE
             throw new NotImplementedException();
         }
 
+        protected void RenderPasses()
+        {
+            // note: only buffer 0 is rendered
+            vaoModel[0].UserCullMode = _cullmode;
+            RenderFramePass(BlendMode.Solid);
+            if (render.EnableTexture)
+            {
+                RenderFramePass(BlendMode.Trans);
+                RenderFramePass(BlendMode.Subtractive);
+                RenderFramePass(BlendMode.Additive);
+            }
+        }
+
         protected void RenderFramePass(BlendMode pass)
         {
             if ((pass & blend_mask) != BlendMode.None)

--- a/CrashEdit/Controls/3D/BaseAnimationEntryViewer.cs
+++ b/CrashEdit/Controls/3D/BaseAnimationEntryViewer.cs
@@ -1,0 +1,97 @@
+﻿using CrashEdit.CE.Properties;
+using CrashEdit.Crash;
+using OpenTK.Graphics.OpenGL4;
+using OpenTK.Mathematics;
+
+namespace CrashEdit.CE
+{
+    public abstract class BaseAnimationEntryViewer : GLViewer
+    {
+        protected int animId;
+        protected int animFrame;
+        protected int modelId;
+
+        protected int _curframe = 0;
+        protected int _cullmode = 1;
+        protected bool _collision = Settings.Default.DisplayFrameCollision;
+        protected bool _interpolate = true;
+        protected bool _halfspeed = false;
+
+        private static VBO[] vboModel = new VBO[2];
+        protected VAO[] vaoModel = new VAO[2];
+        protected BlendMode blend_mask;
+
+        protected readonly Vector3[][] vertCache = new Vector3[2][];
+
+        public BaseAnimationEntryViewer(NSF nsf, int anim_eid, int frame = -1, int model_eid = Entry.NullEID) : base(nsf)
+        {
+            animId = anim_eid;
+            animFrame = frame;
+            modelId = model_eid;
+
+            for (int i = 0; i < vertCache.Length; ++i)
+            {
+                vertCache[i] = [];
+            }
+        }
+
+        private static void LoadGLStatic()
+        {
+            for (int i = 0; i < vboModel.Length; ++i)
+            {
+                vboModel[i] = new();
+            }
+        }
+
+        protected override void LoadGL()
+        {
+            base.LoadGL();
+
+            for (int i = 0; i < vaoModel.Length; ++i)
+            {
+                vaoModel[i] = new(shaders.GetShader("crash1"), PrimitiveType.Triangles, vboModel[i]);
+            }
+        }
+
+        protected override void PrintHelp()
+        {
+            base.PrintHelp();
+            con_help += KeyboardControls.ToggleCollisionAnim.Print(OnOffName(_collision));
+            con_help += KeyboardControls.ToggleLerp.Print(OnOffName(_interpolate));
+            con_help += KeyboardControls.ChangeCullMode.Print(CullModeName(_cullmode));
+        }
+
+        protected override void RunLogic()
+        {
+            base.RunLogic();
+            if (KPress(KeyboardControls.ToggleCollisionAnim)) _collision = !_collision;
+            if (KPress(KeyboardControls.ToggleLerp)) _interpolate = !_interpolate;
+            if (KPress(KeyboardControls.ChangeCullMode)) _cullmode = ++_cullmode % 3;
+        }
+
+        protected override void CollectTPAGs()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected void RenderFramePass(BlendMode pass)
+        {
+            if ((pass & blend_mask) != BlendMode.None)
+            {
+                SetBlendMode(pass);
+                vaoModel[0].BlendMask = BlendModeIndex(pass);
+                vaoModel[0].Render(render);
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            for (var i = 0; i < vaoModel.Length; ++i)
+            {
+                vaoModel[i]?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/CrashEdit/Controls/3D/BaseSceneryEntryViewer.cs
+++ b/CrashEdit/Controls/3D/BaseSceneryEntryViewer.cs
@@ -1,0 +1,99 @@
+﻿using CrashEdit.Crash;
+using OpenTK.Mathematics;
+using OpenTK.Graphics.OpenGL4;
+
+namespace CrashEdit.CE
+{
+    public abstract class BaseSceneryEntryViewer<T> : GLViewer where T : class, IEntry
+    {
+        private List<int> worlds;
+
+        private static VBO vboWorld;
+        protected VAO vaoWorld;
+        protected Vector3 world_offset;
+        protected BlendMode blend_mask;
+
+        public BaseSceneryEntryViewer(NSF nsf, int world) : base(nsf)
+        {
+            worlds = [world];
+        }
+
+        public BaseSceneryEntryViewer(NSF nsf, IEnumerable<int> worlds) : base(nsf)
+        {
+            this.worlds = new(worlds);
+        }
+
+        private static void LoadGLStatic()
+        {
+            vboWorld = new VBO();
+        }
+
+        protected override void LoadGL()
+        {
+            base.LoadGL();
+
+            vaoWorld = new(shaders.GetShader("crash1"), PrimitiveType.Triangles, vboWorld);
+        }
+
+        protected void SetWorlds(IEnumerable<int> worlds)
+        {
+            this.worlds = new(worlds);
+        }
+
+        protected List<T?> GetWorlds()
+        {
+            var list = new List<T?>();
+            foreach (int eid in worlds)
+            {
+                T? world = nsf.GetEntry<T>(eid);
+                if (!list.Contains(world))
+                    list.Add(world);
+            }
+            return list;
+        }
+
+        protected abstract void SetWorldOffset(T world);
+
+        protected override void Render()
+        {
+            base.Render();
+
+            // setup textures
+            CollectTPAGs();
+            UploadTPAGs();
+
+            blend_mask = BlendMode.Solid;
+        }
+
+        protected abstract void RenderWorld(T world);
+
+        protected void RenderPasses()
+        {
+            // render passes
+            RenderWorldPass(BlendMode.Solid);
+            if (render.EnableTexture)
+            {
+                RenderWorldPass(BlendMode.Trans);
+                RenderWorldPass(BlendMode.Subtractive);
+                RenderWorldPass(BlendMode.Additive);
+            }
+        }
+
+        protected void RenderWorldPass(BlendMode pass)
+        {
+            if ((pass & blend_mask) != BlendMode.None)
+            {
+                SetBlendMode(pass);
+                vaoWorld.BlendMask = BlendModeIndex(pass);
+                vaoWorld.Render(render);
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            vaoWorld?.Dispose();
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/CrashEdit/Controls/3D/GLViewer.cs
+++ b/CrashEdit/Controls/3D/GLViewer.cs
@@ -362,10 +362,10 @@ namespace CrashEdit.CE
         {
             switch (mode)
             {
-                case 0: return "frontface culling";
+                default:
+                case 0: return "no culling";
                 case 1: return "backface culling";
-                case 2:
-                default: return "no culling";
+                case 2: return "frontface culling";
             }
         }
 

--- a/CrashEdit/Controls/3D/GLViewerLoader.cs
+++ b/CrashEdit/Controls/3D/GLViewerLoader.cs
@@ -88,5 +88,10 @@ namespace CrashEdit.CE
             fontTable = new();
             texFont = fontTable.LoadFontAndUpload(GL.GenTexture(), fontLib, Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Fonts), Settings.Default.FontName), Settings.Default.FontSize);
         }
+
+        protected override void CollectTPAGs()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/CrashEdit/Controls/3D/OldAnimationEntryViewer.cs
+++ b/CrashEdit/Controls/3D/OldAnimationEntryViewer.cs
@@ -117,15 +117,7 @@ namespace CrashEdit.CE
 
                 UploadTPAGs();
 
-                // note: only buffer 0 is rendered
-                vaoModel[0].UserCullMode = _cullmode;
-                RenderFramePass(BlendMode.Solid);
-                if (render.EnableTexture)
-                {
-                    RenderFramePass(BlendMode.Trans);
-                    RenderFramePass(BlendMode.Subtractive);
-                    RenderFramePass(BlendMode.Additive);
-                }
+                RenderPasses();
 
                 if (_normals && !colored)
                 {

--- a/CrashEdit/Controls/3D/OldAnimationEntryViewer.cs
+++ b/CrashEdit/Controls/3D/OldAnimationEntryViewer.cs
@@ -1,57 +1,21 @@
 using CrashEdit.CE.Properties;
 using CrashEdit.Crash;
-using OpenTK.Graphics.OpenGL4;
 using OpenTK.Mathematics;
 
 namespace CrashEdit.CE
 {
-    public sealed class OldAnimationEntryViewer : GLViewer
+    public sealed class OldAnimationEntryViewer : BaseAnimationEntryViewer
     {
-        private readonly int eid_anim;
-        private readonly int frame_id;
-        private int cur_frame = 0;
         private bool colored;
-        private bool enable_collision = Settings.Default.DisplayFrameCollision;
-        private bool enable_normals = Settings.Default.DisplayNormals;
-        private bool enable_interp = true;
-        private int cull_mode = 1;
+        private bool _normals = Settings.Default.DisplayNormals;
 
-        private static VBO[] vboModel;
-        private VAO[] vaoModel = new VAO[2];
-        private BlendMode blend_mask;
+        public OldAnimationEntryViewer(NSF nsf, int anim_eid, int frame = -1) : base(nsf, anim_eid, frame) { }
 
-        public OldAnimationEntryViewer(NSF nsf, int anim_eid, int frame) : base(nsf)
+        private List<OldFrame>? GetFrames()
         {
-            eid_anim = anim_eid;
-            frame_id = frame;
-        }
-
-        public OldAnimationEntryViewer(NSF nsf, int anim_eid) : base(nsf)
-        {
-            eid_anim = anim_eid;
-            frame_id = -1;
-        }
-
-        private static void LoadGLStatic()
-        {
-            vboModel = [new(), new()];
-        }
-
-        protected override void LoadGL()
-        {
-            base.LoadGL();
-
-            for (int i = 0; i < 2; ++i)
+            List<OldFrame>? frames = null;
             {
-                vaoModel[i] = new(shaders.GetShader("crash1"), PrimitiveType.Triangles, vboModel[i]);
-            }
-        }
-
-        private IList<OldFrame> GetFrames()
-        {
-            IList<OldFrame> frames = null;
-            {
-                var entry = nsf.GetEntry<Entry>(eid_anim);
+                var entry = nsf.GetEntry<Entry>(animId);
                 if (entry is OldAnimationEntry svtx)
                 {
                     frames = svtx.Frames;
@@ -70,12 +34,12 @@ namespace CrashEdit.CE
         {
             get
             {
-                IList<OldFrame> frames = GetFrames();
+                var frames = GetFrames();
                 if (frames != null)
                 {
                     var usedframes = new List<OldFrame>();
-                    if (frame_id != -1)
-                        usedframes.Add(frames[frame_id]);
+                    if (animFrame != -1)
+                        usedframes.Add(frames[animFrame]);
                     else
                         usedframes.AddRange(frames);
 
@@ -91,11 +55,11 @@ namespace CrashEdit.CE
                             my = model.ScaleY / GameScales.ModelC1 / GameScales.AnimC1;
                             mz = model.ScaleZ / GameScales.ModelC1 / GameScales.AnimC1;
                         }
+                        var frame_offset = new Position(frame.XOffset, frame.YOffset, frame.ZOffset) - new Position(128, 128, 128);
+                        var scale = new Position(mx, my, mz);
                         foreach (var vert in frame.Vertices)
                         {
-                            yield return (new Position(vert.X, vert.Y, vert.Z)
-                                        - new Position(128, 128, 128)
-                                        + new Position(frame.XOffset, frame.YOffset, frame.ZOffset)) * new Position(mx, my, mz);
+                            yield return (new Position(vert.X, vert.Y, vert.Z) + frame_offset) * scale;
                         }
                     }
                 }
@@ -108,52 +72,38 @@ namespace CrashEdit.CE
         {
             base.Render();
 
-            IList<OldFrame> frames = GetFrames();
+            tpages.Clear();
+
+            var frames = GetFrames();
             if (frames != null)
             {
-                OldFrame frame2 = null;
+                OldFrame? frame2 = null;
                 float interp = 0;
                 if (frames.Count == 1)
-                {
-                    cur_frame = 0;
-                }
-                else if (frame_id != -1)
-                {
-                    cur_frame = frame_id;
-                }
+                    _curframe = 0;
+                else if (animFrame != -1)
+                    _curframe = animFrame;
                 else
                 {
                     double prog = render.FullCurrentFrame / 2;
-                    cur_frame = (int)Math.Floor(prog) % frames.Count;
-                    if (enable_interp)
+                    _curframe = (int)Math.Floor(prog) % frames.Count;
+                    if (_interpolate)
                     {
                         frame2 = frames[(int)Math.Ceiling(prog) % frames.Count];
-                        interp = (float)(prog - Math.Floor(prog));
-                        // Console.WriteLine(string.Format("Render frame {1}+{2}/{0} (i {3})", anim.Frames.Count, cur_frame, (int)Math.Ceiling(prog) % anim.Frames.Count, interp));
+                        interp = (float)(prog - Math.Truncate(prog));
+                        // Console.WriteLine(string.Format("Render frame {1}+{2}/{0} (i {3})", anim.Frames.Count, _curframe, (int)Math.Ceiling(prog) % anim.Frames.Count, interp));
                     }
                 }
-                OldFrame frame1 = frames[cur_frame];
-                if (frame2 != null && (frame2.ModelEID != frame1.ModelEID || frame1.Vertices.Count != frame2.Vertices.Count))
-                    frame2 = null;
-
-                var model = nsf.GetEntry<OldModelEntry>(frame1.ModelEID);
-                if (model == null) return;
+                OldFrame frame1 = frames[_curframe];
 
                 blend_mask = BlendMode.Solid;
 
                 RenderFrame(frame1, 0);
 
-                // uniforms and static data
-                vaoModel[0].UserTrans = new(frame1.XOffset, frame1.YOffset, frame1.ZOffset);
-                vaoModel[0].UserScale = new Vector3(model.ScaleX, model.ScaleY, model.ScaleZ) / (GameScales.ModelC1 * GameScales.AnimC1);
-                vaoModel[0].UserCullMode = cull_mode;
-
-                if (frame2 != null && frame2 != frame1)
+                if (frame2 != null && frame2 != frame1 && frame1.Vertices.Count == frame2.Vertices.Count)
                 {
                     // lerp results
                     RenderFrame(frame2, 1);
-
-                    MathExt.Lerp(ref vaoModel[0].UserTrans, new Vector3(frame2.XOffset, frame2.YOffset, frame2.ZOffset), interp);
 
                     for (int i = 0; i < vaoModel[0].CurVert; ++i)
                     {
@@ -165,25 +115,27 @@ namespace CrashEdit.CE
                     }
                 }
 
-                vaoModel[0].UserTrans -= new Vector3(128);
+                UploadTPAGs();
 
                 // note: only buffer 0 is rendered
+                vaoModel[0].UserCullMode = _cullmode;
                 RenderFramePass(BlendMode.Solid);
-                RenderFramePass(BlendMode.Trans);
-                RenderFramePass(BlendMode.Subtractive);
-                RenderFramePass(BlendMode.Additive);
-
-                if (enable_normals && !colored)
+                if (render.EnableTexture)
                 {
-                    var ofs = vaoModel[0].UserTrans;
+                    RenderFramePass(BlendMode.Trans);
+                    RenderFramePass(BlendMode.Subtractive);
+                    RenderFramePass(BlendMode.Additive);
+                }
+
+                if (_normals && !colored)
+                {
                     for (int i = 0; i < vaoModel[0].CurVert; ++i)
                     {
-                        var p = (vaoModel[0].Verts[i].trans + ofs) * vaoModel[0].UserScale;
-                        vaoLines.PushAttrib(trans: p, rgba: (Rgba)Color4.White);
-                        vaoLines.PushAttrib(trans: p + Vertex.UnpackNormal(vaoModel[0].Verts[i].normal) * 0.1f, rgba: (Rgba)Color4.Cyan);
+                        vaoLines.PushAttrib(trans: vaoModel[0].Verts[i].trans, rgba: (Rgba)Color4.White);
+                        vaoLines.PushAttrib(trans: vaoModel[0].Verts[i].trans + Vertex.UnpackNormal(vaoModel[0].Verts[i].normal) * 0.1f, rgba: (Rgba)Color4.Cyan);
                     }
                 }
-                if (enable_collision)
+                if (_collision)
                 {
                     var c1 = new Vector3(frame1.collision.X1, frame1.collision.Y1, frame1.collision.Z1) / GameScales.CollisionC1;
                     var c2 = new Vector3(frame1.collision.X2, frame1.collision.Y2, frame1.collision.Z2) / GameScales.CollisionC1;
@@ -193,60 +145,49 @@ namespace CrashEdit.CE
                     AddBox(pos, size, new Rgba(0, 255, 0, 255 / 5), false);
                     AddBox(pos, size, new Rgba(0, 255, 0, 255), true);
                 }
-
-                // restore things
-                vaoModel[0].UserTrans = new Vector3(0);
-                vaoModel[0].UserScale = new Vector3(1);
-                vaoModel[0].UserCullMode = 0;
             }
         }
 
         protected override void PrintHelp()
         {
             base.PrintHelp();
-            con_help += KeyboardControls.ToggleCollisionAnim.Print(OnOffName(enable_collision));
-            con_help += KeyboardControls.ToggleLerp.Print(OnOffName(enable_interp));
-            con_help += KeyboardControls.ChangeCullMode.Print(CullModeName(cull_mode));
-            con_help += KeyboardControls.ToggleNormals.Print(OnOffName(enable_normals));
+            con_help += KeyboardControls.ToggleNormals.Print(OnOffName(_normals));
         }
 
         protected override void RunLogic()
         {
             base.RunLogic();
-            if (KPress(KeyboardControls.ToggleCollisionAnim)) enable_collision = !enable_collision;
-            if (KPress(KeyboardControls.ToggleLerp)) enable_interp = !enable_interp;
-            if (KPress(KeyboardControls.ChangeCullMode)) cull_mode = ++cull_mode % 3;
-            if (KPress(KeyboardControls.ToggleNormals)) enable_normals = !enable_normals;
+            if (KPress(KeyboardControls.ToggleNormals)) _normals = !_normals;
         }
 
-        private Dictionary<int, short> CollectTPAGs(OldModelEntry model)
+        private void AddTPAGs(OldModelEntry model)
         {
             // collect tpag eids
-            Dictionary<int, short> tex_eids = new();
             foreach (OldModelStruct str in model.Structs)
             {
-                if (str is OldModelTexture tex && !tex_eids.ContainsKey(tex.EID))
+                if (str is OldModelTexture tex && !tpages.ContainsKey(tex.EID))
                 {
-                    tex_eids[tex.EID] = (short)tex_eids.Count;
+                    tpages[tex.EID] = (short)tpages.Count;
                 }
             }
-            return tex_eids;
         }
 
         private void RenderFrame(OldFrame frame, int buf)
         {
+            var vao = vaoModel[buf];
+            vao.DiscardVerts();
+
             var model = nsf.GetEntry<OldModelEntry>(frame.ModelEID);
             if (model != null)
             {
                 // setup textures
-                var tex_eids = CollectTPAGs(model);
-                SetupTPAGs(tex_eids);
+                AddTPAGs(model);
 
                 // alloc buffers
-                var vao = vaoModel[buf];
-                int nb = model.Polygons.Count * 3;
-                vao.TestRealloc(nb);
-                vao.DiscardVerts();
+                vao.TestRealloc(model.Polygons.Count * 3);
+
+                var trans = new Vector3(frame.XOffset, frame.YOffset, frame.ZOffset) - new Vector3(128);
+                var scale = new Vector3(model.ScaleX, model.ScaleY, model.ScaleZ) / (GameScales.ModelC1 * GameScales.AnimC1);
 
                 // render stuff
                 foreach (OldModelPolygon polygon in model.Polygons)
@@ -256,54 +197,38 @@ namespace CrashEdit.CE
                     if (str is OldModelTexture tex)
                     {
                         vao.Verts[cur_idx].rgba = new(tex.R, tex.G, tex.B, 255);
-                        vao.Verts[cur_idx + 1].rgba = vao.Verts[cur_idx].rgba;
-                        vao.Verts[cur_idx + 2].rgba = vao.Verts[cur_idx].rgba;
+
                         vao.Verts[cur_idx + 0].st = new(tex.U3, tex.V3);
                         vao.Verts[cur_idx + 1].st = new(tex.U2, tex.V2);
                         vao.Verts[cur_idx + 2].st = new(tex.U1, tex.V1);
-                        vao.Verts[cur_idx + 0].tex = new VertexTexInfo(tex_eids[tex.EID], color: tex.ColorMode, blend: tex.BlendMode,
-                                                                                          clutx: tex.ClutX, cluty: tex.ClutY,
-                                                                                          face: Convert.ToInt32(tex.N));
-                        vao.Verts[cur_idx + 1].tex = vao.Verts[cur_idx + 0].tex;
-                        vao.Verts[cur_idx + 2].tex = vao.Verts[cur_idx + 0].tex;
-                        RenderVertex(vao, frame, polygon.VertexC / 6);
-                        RenderVertex(vao, frame, polygon.VertexB / 6);
-                        RenderVertex(vao, frame, polygon.VertexA / 6);
 
+                        vao.Verts[cur_idx].tex = new VertexTexInfo(tpages[tex.EID], color: tex.ColorMode, blend: tex.BlendMode,
+                                                                                    clutx: tex.ClutX, cluty: tex.ClutY,
+                                                                                    face: Convert.ToInt32(tex.N));
+                        
                         blend_mask |= VertexTexInfo.GetBlendMode(tex.BlendMode);
                     }
                     else
                     {
                         OldSceneryColor col = (OldSceneryColor)str;
                         vao.Verts[cur_idx].rgba = new(col.R, col.G, col.B, 255);
-                        vao.Verts[cur_idx + 1].rgba = vao.Verts[cur_idx].rgba;
-                        vao.Verts[cur_idx + 2].rgba = vao.Verts[cur_idx].rgba;
-                        vao.Verts[cur_idx + 0].tex = new VertexTexInfo(-1, face: Convert.ToInt32(col.N));
-                        vao.Verts[cur_idx + 1].tex = vao.Verts[cur_idx + 0].tex;
-                        vao.Verts[cur_idx + 2].tex = vao.Verts[cur_idx + 0].tex;
-                        RenderVertex(vao, frame, polygon.VertexC / 6);
-                        RenderVertex(vao, frame, polygon.VertexB / 6);
-                        RenderVertex(vao, frame, polygon.VertexA / 6);
+                        vao.Verts[cur_idx].tex = new VertexTexInfo(-1, face: Convert.ToInt32(col.N));
                     }
+                    vao.Verts[cur_idx + 1].rgba = vao.Verts[cur_idx].rgba;
+                    vao.Verts[cur_idx + 2].rgba = vao.Verts[cur_idx].rgba;
+                    vao.Verts[cur_idx + 1].tex = vao.Verts[cur_idx + 0].tex;
+                    vao.Verts[cur_idx + 2].tex = vao.Verts[cur_idx + 0].tex;
+                    RenderVertex(vao, frame.Vertices[polygon.VertexC / 6], trans, scale);
+                    RenderVertex(vao, frame.Vertices[polygon.VertexB / 6], trans, scale);
+                    RenderVertex(vao, frame.Vertices[polygon.VertexA / 6], trans, scale);
                 }
             }
         }
 
-        private void RenderFramePass(BlendMode pass)
+        private void RenderVertex(VAO vao, in OldFrameVertex vert, Vector3 trans, Vector3 scale)
         {
-            if ((pass & blend_mask) != BlendMode.None)
-            {
-                SetBlendMode(pass);
-                vaoModel[0].BlendMask = BlendModeIndex(pass);
-                vaoModel[0].Render(render);
-            }
-        }
-
-        private void RenderVertex(VAO vao, OldFrame frame, int vert_idx)
-        {
-            OldFrameVertex vert = frame.Vertices[vert_idx];
             int cur_vert_idx = vao.CurVert;
-            vao.Verts[cur_vert_idx].trans = new(vert.X, vert.Y, vert.Z);
+            vao.Verts[cur_vert_idx].trans = (new Vector3(vert.X, vert.Y, vert.Z) + trans) * scale;
             if (colored)
             {
                 Rgba old_rgba = vao.Verts[cur_vert_idx].rgba;
@@ -316,16 +241,6 @@ namespace CrashEdit.CE
                 vao.Verts[cur_vert_idx].normal = Vertex.PackNormal(new Vector3(vert.NormalX, vert.NormalY, vert.NormalZ) / 127);
             }
             vao.CurVert++;
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            for (var i = 0; i < vaoModel.Length; ++i)
-            {
-                vaoModel[i]?.Dispose();
-            }
-
-            base.Dispose(disposing);
         }
     }
 }

--- a/CrashEdit/CrashEdit.csproj
+++ b/CrashEdit/CrashEdit.csproj
@@ -75,6 +75,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Update="Properties\Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
     <Compile Update="Properties\Settings.Designer.cs">
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
       <AutoGen>True</AutoGen>
@@ -84,10 +89,13 @@
 
   <ItemGroup>
     <EmbeddedResource Update="Properties\Resources.ja.resx">
-      <CustomToolNamespace>CrashEdit.CE.Properties</CustomToolNamespace>
+      <CustomToolNamespace></CustomToolNamespace>
+      <Generator>ResXFileCodeGenerator</Generator>
     </EmbeddedResource>
     <EmbeddedResource Update="Properties\Resources.resx">
-      <CustomToolNamespace>CrashEdit.CE.Properties</CustomToolNamespace>
+      <CustomToolNamespace></CustomToolNamespace>
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
 

--- a/CrashEdit/Properties/Resources.Designer.cs
+++ b/CrashEdit/Properties/Resources.Designer.cs
@@ -88,15 +88,6 @@ namespace CrashEdit.CE.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cache shader uniform locations.
-        /// </summary>
-        internal static string Config_chkCacheShaderUniformLoc {
-            get {
-                return ResourceManager.GetString("Config_chkCacheShaderUniformLoc", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Display frame collision by default.
         /// </summary>
         internal static string Config_chkCollisionDisplay {
@@ -241,7 +232,7 @@ namespace CrashEdit.CE.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Amount.
+        ///   Looks up a localized string similar to Size.
         /// </summary>
         internal static string Config_lblAnimGrid {
             get {
@@ -268,29 +259,11 @@ namespace CrashEdit.CE.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Height.
-        /// </summary>
-        internal static string Config_lblH {
-            get {
-                return ResourceManager.GetString("Config_lblH", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Language (requires restart).
         /// </summary>
         internal static string Config_lblLang {
             get {
                 return ResourceManager.GetString("Config_lblLang", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Width.
-        /// </summary>
-        internal static string Config_lblW {
-            get {
-                return ResourceManager.GetString("Config_lblW", resourceCulture);
             }
         }
         
@@ -1819,7 +1792,7 @@ namespace CrashEdit.CE.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hold Ctrl for aligned movement.
+        ///   Looks up a localized string similar to Hold Shift for aligned movement.
         /// </summary>
         internal static string ViewerControls_MoveAligned {
             get {
@@ -1878,6 +1851,15 @@ namespace CrashEdit.CE.Properties {
         internal static string ViewerControls_ToggleNormals {
             get {
                 return ResourceManager.GetString("ViewerControls_ToggleNormals", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Toggle half-speed animations ({0}).
+        /// </summary>
+        internal static string ViewerControls_ToggleSlowAnim {
+            get {
+                return ResourceManager.GetString("ViewerControls_ToggleSlowAnim", resourceCulture);
             }
         }
         

--- a/CrashEdit/Properties/Resources.ja.resx
+++ b/CrashEdit/Properties/Resources.ja.resx
@@ -207,7 +207,6 @@
   <data name="Toolbar_UndoAction" xml:space="preserve">
     <value>取り消し {0}</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="Toolbar_UndoNone" xml:space="preserve">
     <value>取り消し</value>
   </data>

--- a/CrashEdit/Properties/Resources.resx
+++ b/CrashEdit/Properties/Resources.resx
@@ -207,7 +207,6 @@
   <data name="Toolbar_UndoAction" xml:space="preserve">
     <value>Undo {0}</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="Toolbar_UndoNone" xml:space="preserve">
     <value>Undo</value>
   </data>
@@ -688,7 +687,7 @@ as Meters: {3:F3}m</value>
     <value>W/A/S/D to move, Q/E to pan up/down</value>
   </data>
   <data name="ViewerControls_MoveAligned" xml:space="preserve">
-    <value>Hold Ctrl for aligned movement</value>
+    <value>Hold Shift for aligned movement</value>
   </data>
   <data name="ViewerControls_OpenOctreeWindow" xml:space="preserve">
     <value>Open octree node window</value>
@@ -758,5 +757,8 @@ as Meters: {3:F3}m</value>
   </data>
   <data name="ViewerControls_Zoom" xml:space="preserve">
     <value>Scroll wheel to zoom</value>
+  </data>
+  <data name="ViewerControls_ToggleSlowAnim" xml:space="preserve">
+    <value>Toggle half-speed animations ({0})</value>
   </data>
 </root>

--- a/CrashEdit/Render/Shaders/crash1-generic.vert
+++ b/CrashEdit/Render/Shaders/crash1-generic.vert
@@ -8,12 +8,6 @@ in ivec2 tex;
 
 uniform mat4 PVM;
 
-uniform int art;
-
-uniform vec3 trans;
-uniform vec3 scale;
-uniform float scaleScalar;
-
 uniform int blendmask;
 uniform int enableTex;
 
@@ -33,6 +27,6 @@ void main(void)
         // discard wrong blend modes, but always let textures pass on solid render
         gl_Position = vec4(0);
     } else {
-        gl_Position = PVM * vec4( (position+trans)*scale, 1.0 );
+        gl_Position = PVM * vec4( position, 1.0 );
     }
 }

--- a/CrashEdit/Render/VAO.cs
+++ b/CrashEdit/Render/VAO.cs
@@ -100,6 +100,8 @@ namespace CrashEdit.CE
             VBO.TestRealloc(vert_count);
         }
 
+        public ref Vertex GetCurrentVert() => ref Verts[VBO.CurVert];
+
         public void CopyAttrib(int idx)
         {
             TestRealloc();
@@ -110,62 +112,69 @@ namespace CrashEdit.CE
         public void PushAttrib(Vector3 trans = default)
         {
             TestRealloc();
-            Verts[VBO.CurVert].trans = trans;
+            ref var v = ref GetCurrentVert();
+            v.trans = trans;
             VBO.CurVert++;
         }
 
         public void PushAttrib(Vector3 trans = default, Rgba rgba = default)
         {
             TestRealloc();
-            Verts[VBO.CurVert].trans = trans;
-            Verts[VBO.CurVert].rgba = rgba;
+            ref var v = ref GetCurrentVert();
+            v.trans = trans;
+            v.rgba = rgba;
             VBO.CurVert++;
         }
 
         public void PushAttrib(Vector3 trans = default, Vector2 st = default)
         {
             TestRealloc();
-            Verts[VBO.CurVert].trans = trans;
-            Verts[VBO.CurVert].st = st;
+            ref var v = ref GetCurrentVert();
+            v.trans = trans;
+            v.st = st;
             VBO.CurVert++;
         }
 
         public void PushAttrib(Vector3 trans = default, Vector2 st = default, Rgba rgba = default)
         {
             TestRealloc();
-            Verts[VBO.CurVert].trans = trans;
-            Verts[VBO.CurVert].st = st;
-            Verts[VBO.CurVert].rgba = rgba;
+            ref var v = ref GetCurrentVert();
+            v.trans = trans;
+            v.st = st;
+            v.rgba = rgba;
             VBO.CurVert++;
         }
 
         public void PushAttrib(Vector3 trans = default, Vector2 st = default, Rgba rgba = default, Vector4 misc = default)
         {
             TestRealloc();
-            Verts[VBO.CurVert].trans = trans;
-            Verts[VBO.CurVert].st = st;
-            Verts[VBO.CurVert].rgba = rgba;
-            Verts[VBO.CurVert].misc = misc;
+            ref var v = ref GetCurrentVert();
+            v.trans = trans;
+            v.st = st;
+            v.rgba = rgba;
+            v.misc = misc;
             VBO.CurVert++;
         }
 
         public void PushAttrib(Vector3 trans = default, Vector4 misc = default)
         {
             TestRealloc();
-            Verts[VBO.CurVert].trans = trans;
-            Verts[VBO.CurVert].misc = misc;
+            ref var v = ref GetCurrentVert();
+            v.trans = trans;
+            v.misc = misc;
             VBO.CurVert++;
         }
 
         public void PushAttrib(Vector3 trans = default, int normal = default, Vector2 st = default, Rgba rgba = default, VertexTexInfo tex = default, Vector4 misc = default)
         {
             TestRealloc();
-            Verts[VBO.CurVert].trans = trans;
-            Verts[VBO.CurVert].normal = normal;
-            Verts[VBO.CurVert].st = st;
-            Verts[VBO.CurVert].rgba = rgba;
-            Verts[VBO.CurVert].tex = tex;
-            Verts[VBO.CurVert].misc = misc;
+            ref var v = ref GetCurrentVert();
+            v.trans = trans;
+            v.normal = normal;
+            v.st = st;
+            v.rgba = rgba;
+            v.tex = tex;
+            v.misc = misc;
             VBO.CurVert++;
         }
 


### PR DESCRIPTION
Makes every scenery viewer a descendent of `BaseSceneryEntryViewer` and every animation viewer a descendent of `BaseAnimationEntryViewer`.

Also fixes some other bugs.